### PR TITLE
Fullbright fix

### DIFF
--- a/src/main/java/me/bon/badlionplus/module/Render/Fullbright.java
+++ b/src/main/java/me/bon/badlionplus/module/Render/Fullbright.java
@@ -2,22 +2,28 @@ package me.bon.badlionplus.module.Render;
 
 import me.bon.badlionplus.module.Category;
 import me.bon.badlionplus.module.Module;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
+
+import java.util.Objects;
 
 public class Fullbright extends Module {
 	public Fullbright() {
 		super("Fullbright", Category.Render);
+
+		this.tickDelay = 1000;
 	}
-	
-	
+
+
 	@Override
-	public void onEnable() {
-		mc.gameSettings.gammaSetting = 100000000.0F;
+	public void onUpdate() {
+		if (mc.player == null) return;
+
+		mc.player.addPotionEffect(new PotionEffect(Objects.requireNonNull(Potion.getPotionById(16))));
 	}
-	
+
 	@Override
 	public void onDisable() {
-		mc.gameSettings.gammaSetting = 1.0F;
+		mc.player.removeActivePotionEffect(Objects.requireNonNull(Potion.getPotionById(16)));
 	}
-	
-	
 }


### PR DESCRIPTION
fullbright is now giving you a Night Vision potion effect every 1k ticks and removes the effect if it exists when disabling